### PR TITLE
Add support for custom endpoints

### DIFF
--- a/src/custom/backend.ts
+++ b/src/custom/backend.ts
@@ -32,6 +32,7 @@ if (process.env.RUNS_ON_RUNNER_NAME && process.env.RUNS_ON_RUNNER_NAME !== "") {
     delete process.env.AWS_SESSION_TOKEN;
     delete process.env.AWS_REGION;
     delete process.env.AWS_DEFAULT_REGION;
+    delete process.env.AWS_S3_ENDPOINT;
 }
 
 const versionSalt = "1.0";
@@ -43,6 +44,7 @@ const region =
 const forcePathStyle =
     process.env.RUNS_ON_S3_FORCE_PATH_STYLE === "true" ||
     process.env.AWS_S3_FORCE_PATH_STYLE === "true";
+const endpoint = process.env.AWS_S3_ENDPOINT;
 
 const uploadQueueSize = Number(process.env.UPLOAD_QUEUE_SIZE || "4");
 const uploadPartSize =
@@ -51,7 +53,11 @@ const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
 const downloadPartSize =
     Number(process.env.DOWNLOAD_PART_SIZE || "16") * 1024 * 1024;
 
-const s3Client = new S3Client({ region, forcePathStyle });
+const s3Client = new S3Client({
+    endpoint: endpoint,
+    region: region,
+    forcePathStyle: forcePathStyle
+});
 
 export function getCacheVersion(
     paths: string[],


### PR DESCRIPTION
Add support for running on third party S3 compatible implementations.
Fixes #13 

Example usage.
```yaml
steps:
  uses: runs-on/cache@v4
  env:
    AWS_ACCESS_KEY_ID: "access_key"
    AWS_SECRET_ACCESS_KEY: "secret"
    AWS_REGION: "eu-west-1"
    AWS_S3_ENDPOINT: https://s3.example.com
```