### PR TITLE
Support RUNS_ON_S3_DISABLE_PREFIX env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Be aware of S3 transfer costs if your runners are not in the same AWS region as 
 * `RUNS_ON_S3_BUCKET_ENDPOINT`: if set, the action will use this endpoint to connect to the bucket. This is useful if you are using AWS's S3 transfer acceleration or a non-AWS S3-compatible service.
 * `RUNS_ON_RUNNER_NAME`: when running on RunsOn, where this environment variable is non-empty, existing AWS credentials from the environment will be discarded. If you want to preserve existing environment variables, set this to the empty string `""`.
 * `RUNS_ON_S3_FORCE_PATH_STYLE` or `AWS_S3_FORCE_PATH_STYLE`: if one of those environment variables equals the string `"true"`, then the S3 client will be configured to force the path style.
+* `RUNS_ON_S3_DISABLE_PREFIX`: when this environment variable equals the string `"true"`, the default cache prefix (`cache/<repo>/version`) will not be used.
 
 
 ## Action pinning

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -100526,6 +100526,7 @@ const region = process.env.RUNS_ON_AWS_REGION ||
     process.env.AWS_DEFAULT_REGION;
 const forcePathStyle = process.env.RUNS_ON_S3_FORCE_PATH_STYLE === "true" ||
     process.env.AWS_S3_FORCE_PATH_STYLE === "true";
+const disableCachePrefix = process.env.RUNS_ON_S3_DISABLE_PREFIX === "true";
 const uploadQueueSize = Number(process.env.UPLOAD_QUEUE_SIZE || "4");
 const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 1024;
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
@@ -100552,6 +100553,9 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 exports.getCacheVersion = getCacheVersion;
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    if (disableCachePrefix) {
+        return undefined;
+    }
     const repository = process.env.GITHUB_REPOSITORY;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
     return ["cache", repository, version].join("/");
@@ -100567,7 +100571,7 @@ function getCacheEntry(keys, paths, { compressionMethod, enableCrossOsArchive })
             });
             const listObjectsParams = {
                 Bucket: bucketName,
-                Prefix: [s3Prefix, restoreKey].join("/")
+                Prefix: s3Prefix ? [s3Prefix, restoreKey].join("/") : restoreKey
             };
             try {
                 const { Contents = [] } = yield s3Client.send(new client_s3_1.ListObjectsV2Command(listObjectsParams));
@@ -100649,7 +100653,7 @@ function saveCache(key, paths, archivePath, { compressionMethod, enableCrossOsAr
             compressionMethod,
             enableCrossOsArchive
         });
-        const s3Key = `${s3Prefix}/${key}`;
+        const s3Key = s3Prefix ? `${s3Prefix}/${key}` : key;
         const multipartUpload = new lib_storage_1.Upload({
             client: s3Client,
             params: {

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -100526,6 +100526,7 @@ const region = process.env.RUNS_ON_AWS_REGION ||
     process.env.AWS_DEFAULT_REGION;
 const forcePathStyle = process.env.RUNS_ON_S3_FORCE_PATH_STYLE === "true" ||
     process.env.AWS_S3_FORCE_PATH_STYLE === "true";
+const disableCachePrefix = process.env.RUNS_ON_S3_DISABLE_PREFIX === "true";
 const uploadQueueSize = Number(process.env.UPLOAD_QUEUE_SIZE || "4");
 const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 1024;
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
@@ -100552,6 +100553,9 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 exports.getCacheVersion = getCacheVersion;
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    if (disableCachePrefix) {
+        return undefined;
+    }
     const repository = process.env.GITHUB_REPOSITORY;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
     return ["cache", repository, version].join("/");
@@ -100567,7 +100571,7 @@ function getCacheEntry(keys, paths, { compressionMethod, enableCrossOsArchive })
             });
             const listObjectsParams = {
                 Bucket: bucketName,
-                Prefix: [s3Prefix, restoreKey].join("/")
+                Prefix: s3Prefix ? [s3Prefix, restoreKey].join("/") : restoreKey
             };
             try {
                 const { Contents = [] } = yield s3Client.send(new client_s3_1.ListObjectsV2Command(listObjectsParams));
@@ -100649,7 +100653,7 @@ function saveCache(key, paths, archivePath, { compressionMethod, enableCrossOsAr
             compressionMethod,
             enableCrossOsArchive
         });
-        const s3Key = `${s3Prefix}/${key}`;
+        const s3Key = s3Prefix ? `${s3Prefix}/${key}` : key;
         const multipartUpload = new lib_storage_1.Upload({
             client: s3Client,
             params: {

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -100526,6 +100526,7 @@ const region = process.env.RUNS_ON_AWS_REGION ||
     process.env.AWS_DEFAULT_REGION;
 const forcePathStyle = process.env.RUNS_ON_S3_FORCE_PATH_STYLE === "true" ||
     process.env.AWS_S3_FORCE_PATH_STYLE === "true";
+const disableCachePrefix = process.env.RUNS_ON_S3_DISABLE_PREFIX === "true";
 const uploadQueueSize = Number(process.env.UPLOAD_QUEUE_SIZE || "4");
 const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 1024;
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
@@ -100552,6 +100553,9 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 exports.getCacheVersion = getCacheVersion;
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    if (disableCachePrefix) {
+        return undefined;
+    }
     const repository = process.env.GITHUB_REPOSITORY;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
     return ["cache", repository, version].join("/");
@@ -100567,7 +100571,7 @@ function getCacheEntry(keys, paths, { compressionMethod, enableCrossOsArchive })
             });
             const listObjectsParams = {
                 Bucket: bucketName,
-                Prefix: [s3Prefix, restoreKey].join("/")
+                Prefix: s3Prefix ? [s3Prefix, restoreKey].join("/") : restoreKey
             };
             try {
                 const { Contents = [] } = yield s3Client.send(new client_s3_1.ListObjectsV2Command(listObjectsParams));
@@ -100649,7 +100653,7 @@ function saveCache(key, paths, archivePath, { compressionMethod, enableCrossOsAr
             compressionMethod,
             enableCrossOsArchive
         });
-        const s3Key = `${s3Prefix}/${key}`;
+        const s3Key = s3Prefix ? `${s3Prefix}/${key}` : key;
         const multipartUpload = new lib_storage_1.Upload({
             client: s3Client,
             params: {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -100526,6 +100526,7 @@ const region = process.env.RUNS_ON_AWS_REGION ||
     process.env.AWS_DEFAULT_REGION;
 const forcePathStyle = process.env.RUNS_ON_S3_FORCE_PATH_STYLE === "true" ||
     process.env.AWS_S3_FORCE_PATH_STYLE === "true";
+const disableCachePrefix = process.env.RUNS_ON_S3_DISABLE_PREFIX === "true";
 const uploadQueueSize = Number(process.env.UPLOAD_QUEUE_SIZE || "4");
 const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 1024;
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
@@ -100552,6 +100553,9 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 exports.getCacheVersion = getCacheVersion;
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    if (disableCachePrefix) {
+        return undefined;
+    }
     const repository = process.env.GITHUB_REPOSITORY;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
     return ["cache", repository, version].join("/");
@@ -100567,7 +100571,7 @@ function getCacheEntry(keys, paths, { compressionMethod, enableCrossOsArchive })
             });
             const listObjectsParams = {
                 Bucket: bucketName,
-                Prefix: [s3Prefix, restoreKey].join("/")
+                Prefix: s3Prefix ? [s3Prefix, restoreKey].join("/") : restoreKey
             };
             try {
                 const { Contents = [] } = yield s3Client.send(new client_s3_1.ListObjectsV2Command(listObjectsParams));
@@ -100649,7 +100653,7 @@ function saveCache(key, paths, archivePath, { compressionMethod, enableCrossOsAr
             compressionMethod,
             enableCrossOsArchive
         });
-        const s3Key = `${s3Prefix}/${key}`;
+        const s3Key = s3Prefix ? `${s3Prefix}/${key}` : key;
         const multipartUpload = new lib_storage_1.Upload({
             client: s3Client,
             params: {

--- a/src/custom/backend.ts
+++ b/src/custom/backend.ts
@@ -43,6 +43,7 @@ const region =
 const forcePathStyle =
     process.env.RUNS_ON_S3_FORCE_PATH_STYLE === "true" ||
     process.env.AWS_S3_FORCE_PATH_STYLE === "true";
+const disableCachePrefix = process.env.RUNS_ON_S3_DISABLE_PREFIX === "true";
 
 const uploadQueueSize = Number(process.env.UPLOAD_QUEUE_SIZE || "4");
 const uploadPartSize =
@@ -84,7 +85,11 @@ export function getCacheVersion(
 function getS3Prefix(
     paths: string[],
     { compressionMethod, enableCrossOsArchive }
-): string {
+): string | undefined {
+    if (disableCachePrefix) {
+        return undefined;
+    }
+
     const repository = process.env.GITHUB_REPOSITORY;
     const version = getCacheVersion(
         paths,
@@ -110,7 +115,7 @@ export async function getCacheEntry(
         });
         const listObjectsParams = {
             Bucket: bucketName,
-            Prefix: [s3Prefix, restoreKey].join("/")
+            Prefix: s3Prefix ? [s3Prefix, restoreKey].join("/") : restoreKey
         };
 
         try {
@@ -224,7 +229,7 @@ export async function saveCache(
         compressionMethod,
         enableCrossOsArchive
     });
-    const s3Key = `${s3Prefix}/${key}`;
+    const s3Key = s3Prefix ? `${s3Prefix}/${key}` : key;
 
     const multipartUpload = new Upload({
         client: s3Client,


### PR DESCRIPTION
Fixes https://github.com/runs-on/cache/issues/21

This PR adds support for a `RUNS_ON_S3_DISABLE_PREFIX` environment variable that completely disables the custom cache prefix, which is useful in a variety of scenarios:

- Cross-repository caching
- Partial path restoration (this is the case that I need)
- Generally making cache keys predictable

I briefly considered allowing a custom prefix to be passed in, but that is really the purpose of the `key` input, which can accept path segments.