### PR TITLE
Use RunsOn repository cache prefix

### DIFF
--- a/__tests__/customBackend.test.ts
+++ b/__tests__/customBackend.test.ts
@@ -1,0 +1,36 @@
+import { getCacheVersion, getS3Prefix } from "../src/custom/prefix";
+
+afterEach(() => {
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+});
+
+test("S3 prefix uses RunsOn shared cache prefix when available", () => {
+    process.env.GITHUB_REPOSITORY = "runs-on/monorepo";
+    process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX =
+        "/cache/shared/runs-on/monorepo/";
+
+    const paths = ["node_modules"];
+    const version = getCacheVersion(paths);
+
+    expect(
+        getS3Prefix(paths, {
+            compressionMethod: undefined,
+            enableCrossOsArchive: false
+        })
+    ).toBe(`cache/shared/runs-on/monorepo/${version}`);
+});
+
+test("S3 prefix keeps legacy repository layout without RunsOn shared prefix", () => {
+    process.env.GITHUB_REPOSITORY = "runs-on/monorepo";
+
+    const paths = ["node_modules"];
+    const version = getCacheVersion(paths);
+
+    expect(
+        getS3Prefix(paths, {
+            compressionMethod: undefined,
+            enableCrossOsArchive: false
+        })
+    ).toBe(`cache/runs-on/monorepo/${version}`);
+});

--- a/__tests__/customBackend.test.ts
+++ b/__tests__/customBackend.test.ts
@@ -2,13 +2,12 @@ import { getCacheVersion, getS3Prefix } from "../src/custom/prefix";
 
 afterEach(() => {
     delete process.env.GITHUB_REPOSITORY;
-    delete process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    delete process.env.RUNS_ON_S3_CACHE_REPO_PREFIX;
 });
 
-test("S3 prefix uses RunsOn shared cache prefix when available", () => {
+test("S3 prefix uses RunsOn repo cache prefix when available", () => {
     process.env.GITHUB_REPOSITORY = "runs-on/monorepo";
-    process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX =
-        "/cache/shared/runs-on/monorepo/";
+    process.env.RUNS_ON_S3_CACHE_REPO_PREFIX = "/cache/repo/runs-on/monorepo/";
 
     const paths = ["node_modules"];
     const version = getCacheVersion(paths);
@@ -18,10 +17,10 @@ test("S3 prefix uses RunsOn shared cache prefix when available", () => {
             compressionMethod: undefined,
             enableCrossOsArchive: false
         })
-    ).toBe(`cache/shared/runs-on/monorepo/${version}`);
+    ).toBe(`cache/repo/runs-on/monorepo/${version}`);
 });
 
-test("S3 prefix keeps legacy repository layout without RunsOn shared prefix", () => {
+test("S3 prefix keeps legacy repository layout without RunsOn repo prefix", () => {
     process.env.GITHUB_REPOSITORY = "runs-on/monorepo";
 
     const paths = ["node_modules"];

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -73306,18 +73306,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCacheVersion = getCacheVersion;
 exports.getCacheEntry = getCacheEntry;
 exports.downloadCache = downloadCache;
 exports.saveCache = saveCache;
-const client_s3_1 = __nccwpck_require__(53711);
-const { getSignedUrl } = __nccwpck_require__(18505);
-const fs_1 = __nccwpck_require__(79896);
-const crypto = __importStar(__nccwpck_require__(76982));
-const core = __importStar(__nccwpck_require__(37484));
 const utils = __importStar(__nccwpck_require__(98299));
+const core = __importStar(__nccwpck_require__(37484));
+const client_s3_1 = __nccwpck_require__(53711);
 const lib_storage_1 = __nccwpck_require__(22358);
+const s3_request_presigner_1 = __nccwpck_require__(18505);
+const fs_1 = __nccwpck_require__(79896);
 const downloadUtils_1 = __nccwpck_require__(118);
+const prefix_1 = __nccwpck_require__(33327);
 // if executing from RunsOn, unset any existing AWS credential env variables so that we can use the IAM instance profile for credentials
 // see unsetCredentials() in https://github.com/aws-actions/configure-aws-credentials/blob/v4.0.2/src/helpers.ts#L44
 // Note: we preserve AWS_REGION and AWS_DEFAULT_REGION as they are needed for SDK initialization
@@ -73326,7 +73325,6 @@ if (process.env.RUNS_ON_RUNNER_NAME && process.env.RUNS_ON_RUNNER_NAME !== "") {
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
 }
-const versionSalt = "1.0";
 const bucketName = process.env.RUNS_ON_S3_BUCKET_CACHE;
 const endpoint = process.env.RUNS_ON_S3_BUCKET_ENDPOINT;
 const region = process.env.RUNS_ON_AWS_REGION ||
@@ -73339,36 +73337,12 @@ const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 102
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
 const downloadPartSize = Number(process.env.DOWNLOAD_PART_SIZE || "16") * 1024 * 1024;
 const s3Client = new client_s3_1.S3Client({ region, forcePathStyle, endpoint });
-function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
-    // don't pass changes upstream
-    const components = paths.slice();
-    // Add compression method to cache version to restore
-    // compressed cache as per compression method
-    if (compressionMethod) {
-        components.push(compressionMethod);
-    }
-    // Only check for windows platforms if enableCrossOsArchive is false
-    if (process.platform === "win32" && !enableCrossOsArchive) {
-        components.push("windows-only");
-    }
-    // Add salt to cache version to support breaking changes in cache entry
-    components.push(versionSalt);
-    return crypto
-        .createHash("sha256")
-        .update(components.join("|"))
-        .digest("hex");
-}
-function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
-    const repository = process.env.GITHUB_REPOSITORY;
-    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    return ["cache", repository, version].join("/");
-}
 function getCacheEntry(keys_1, paths_1, _a) {
     return __awaiter(this, arguments, void 0, function* (keys, paths, { compressionMethod, enableCrossOsArchive }) {
         const cacheEntry = {};
         // Find the most recent key matching one of the restoreKeys prefixes
         for (const restoreKey of keys) {
-            const s3Prefix = getS3Prefix(paths, {
+            const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
                 compressionMethod,
                 enableCrossOsArchive
             });
@@ -73413,7 +73387,7 @@ function downloadCache(archiveLocation, archivePath, options) {
                     Bucket: bucketName,
                     Key: objectKey
                 });
-                const url = yield getSignedUrl(s3Client, command, {
+                const url = yield (0, s3_request_presigner_1.getSignedUrl)(s3Client, command, {
                     expiresIn: 3600
                 });
                 yield (0, downloadUtils_1.downloadCacheHttpClientConcurrent)(url, archivePath, Object.assign(Object.assign({}, options), { downloadConcurrency: downloadQueueSize, concurrentBlobDownloads: true, partSize: downloadPartSize }));
@@ -73442,15 +73416,16 @@ function downloadCache(archiveLocation, archivePath, options) {
         throw lastError || new Error("Download failed after all retry attempts");
     });
 }
-function saveCache(key_1, paths_1, archivePath_1, _a) {
-    return __awaiter(this, arguments, void 0, function* (key, paths, archivePath, { compressionMethod, enableCrossOsArchive, cacheSize: archiveFileSize }) {
+function saveCache(key, paths, archivePath, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { compressionMethod, enableCrossOsArchive } = options;
         if (!bucketName) {
             throw new Error("Environment variable RUNS_ON_S3_BUCKET_CACHE not set");
         }
         if (!region) {
             throw new Error("Environment variable RUNS_ON_AWS_REGION not set");
         }
-        const s3Prefix = getS3Prefix(paths, {
+        const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
             compressionMethod,
             enableCrossOsArchive
         });
@@ -74027,6 +74002,84 @@ const promiseWithTimeout = (timeoutMs, promise) => __awaiter(void 0, void 0, voi
         return result;
     });
 });
+
+
+/***/ }),
+
+/***/ 33327:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getCacheVersion = getCacheVersion;
+exports.getS3Prefix = getS3Prefix;
+const crypto = __importStar(__nccwpck_require__(76982));
+const versionSalt = "1.0";
+function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
+    // don't pass changes upstream
+    const components = paths.slice();
+    // Add compression method to cache version to restore
+    // compressed cache as per compression method
+    if (compressionMethod) {
+        components.push(compressionMethod);
+    }
+    // Only check for windows platforms if enableCrossOsArchive is false
+    if (process.platform === "win32" && !enableCrossOsArchive) {
+        components.push("windows-only");
+    }
+    // Add salt to cache version to support breaking changes in cache entry
+    components.push(versionSalt);
+    return crypto
+        .createHash("sha256")
+        .update(components.join("|"))
+        .digest("hex");
+}
+function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
+    if (sharedPrefix && sharedPrefix.trim() !== "") {
+        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    }
+    return ["cache", repository, version].join("/");
+}
+function normalizeS3Prefix(prefix) {
+    return prefix.trim().replace(/^\/+|\/+$/g, "");
+}
 
 
 /***/ }),

--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -74070,10 +74070,10 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
     const repository = process.env.GITHUB_REPOSITORY;
-    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const repoPrefix = process.env.RUNS_ON_S3_CACHE_REPO_PREFIX;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    if (sharedPrefix && sharedPrefix.trim() !== "") {
-        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    if (repoPrefix && repoPrefix.trim() !== "") {
+        return [normalizeS3Prefix(repoPrefix), version].join("/");
     }
     return ["cache", repository, version].join("/");
 }

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -73306,18 +73306,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCacheVersion = getCacheVersion;
 exports.getCacheEntry = getCacheEntry;
 exports.downloadCache = downloadCache;
 exports.saveCache = saveCache;
-const client_s3_1 = __nccwpck_require__(53711);
-const { getSignedUrl } = __nccwpck_require__(18505);
-const fs_1 = __nccwpck_require__(79896);
-const crypto = __importStar(__nccwpck_require__(76982));
-const core = __importStar(__nccwpck_require__(37484));
 const utils = __importStar(__nccwpck_require__(98299));
+const core = __importStar(__nccwpck_require__(37484));
+const client_s3_1 = __nccwpck_require__(53711);
 const lib_storage_1 = __nccwpck_require__(22358);
+const s3_request_presigner_1 = __nccwpck_require__(18505);
+const fs_1 = __nccwpck_require__(79896);
 const downloadUtils_1 = __nccwpck_require__(118);
+const prefix_1 = __nccwpck_require__(33327);
 // if executing from RunsOn, unset any existing AWS credential env variables so that we can use the IAM instance profile for credentials
 // see unsetCredentials() in https://github.com/aws-actions/configure-aws-credentials/blob/v4.0.2/src/helpers.ts#L44
 // Note: we preserve AWS_REGION and AWS_DEFAULT_REGION as they are needed for SDK initialization
@@ -73326,7 +73325,6 @@ if (process.env.RUNS_ON_RUNNER_NAME && process.env.RUNS_ON_RUNNER_NAME !== "") {
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
 }
-const versionSalt = "1.0";
 const bucketName = process.env.RUNS_ON_S3_BUCKET_CACHE;
 const endpoint = process.env.RUNS_ON_S3_BUCKET_ENDPOINT;
 const region = process.env.RUNS_ON_AWS_REGION ||
@@ -73339,36 +73337,12 @@ const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 102
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
 const downloadPartSize = Number(process.env.DOWNLOAD_PART_SIZE || "16") * 1024 * 1024;
 const s3Client = new client_s3_1.S3Client({ region, forcePathStyle, endpoint });
-function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
-    // don't pass changes upstream
-    const components = paths.slice();
-    // Add compression method to cache version to restore
-    // compressed cache as per compression method
-    if (compressionMethod) {
-        components.push(compressionMethod);
-    }
-    // Only check for windows platforms if enableCrossOsArchive is false
-    if (process.platform === "win32" && !enableCrossOsArchive) {
-        components.push("windows-only");
-    }
-    // Add salt to cache version to support breaking changes in cache entry
-    components.push(versionSalt);
-    return crypto
-        .createHash("sha256")
-        .update(components.join("|"))
-        .digest("hex");
-}
-function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
-    const repository = process.env.GITHUB_REPOSITORY;
-    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    return ["cache", repository, version].join("/");
-}
 function getCacheEntry(keys_1, paths_1, _a) {
     return __awaiter(this, arguments, void 0, function* (keys, paths, { compressionMethod, enableCrossOsArchive }) {
         const cacheEntry = {};
         // Find the most recent key matching one of the restoreKeys prefixes
         for (const restoreKey of keys) {
-            const s3Prefix = getS3Prefix(paths, {
+            const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
                 compressionMethod,
                 enableCrossOsArchive
             });
@@ -73413,7 +73387,7 @@ function downloadCache(archiveLocation, archivePath, options) {
                     Bucket: bucketName,
                     Key: objectKey
                 });
-                const url = yield getSignedUrl(s3Client, command, {
+                const url = yield (0, s3_request_presigner_1.getSignedUrl)(s3Client, command, {
                     expiresIn: 3600
                 });
                 yield (0, downloadUtils_1.downloadCacheHttpClientConcurrent)(url, archivePath, Object.assign(Object.assign({}, options), { downloadConcurrency: downloadQueueSize, concurrentBlobDownloads: true, partSize: downloadPartSize }));
@@ -73442,15 +73416,16 @@ function downloadCache(archiveLocation, archivePath, options) {
         throw lastError || new Error("Download failed after all retry attempts");
     });
 }
-function saveCache(key_1, paths_1, archivePath_1, _a) {
-    return __awaiter(this, arguments, void 0, function* (key, paths, archivePath, { compressionMethod, enableCrossOsArchive, cacheSize: archiveFileSize }) {
+function saveCache(key, paths, archivePath, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { compressionMethod, enableCrossOsArchive } = options;
         if (!bucketName) {
             throw new Error("Environment variable RUNS_ON_S3_BUCKET_CACHE not set");
         }
         if (!region) {
             throw new Error("Environment variable RUNS_ON_AWS_REGION not set");
         }
-        const s3Prefix = getS3Prefix(paths, {
+        const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
             compressionMethod,
             enableCrossOsArchive
         });
@@ -74027,6 +74002,84 @@ const promiseWithTimeout = (timeoutMs, promise) => __awaiter(void 0, void 0, voi
         return result;
     });
 });
+
+
+/***/ }),
+
+/***/ 33327:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getCacheVersion = getCacheVersion;
+exports.getS3Prefix = getS3Prefix;
+const crypto = __importStar(__nccwpck_require__(76982));
+const versionSalt = "1.0";
+function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
+    // don't pass changes upstream
+    const components = paths.slice();
+    // Add compression method to cache version to restore
+    // compressed cache as per compression method
+    if (compressionMethod) {
+        components.push(compressionMethod);
+    }
+    // Only check for windows platforms if enableCrossOsArchive is false
+    if (process.platform === "win32" && !enableCrossOsArchive) {
+        components.push("windows-only");
+    }
+    // Add salt to cache version to support breaking changes in cache entry
+    components.push(versionSalt);
+    return crypto
+        .createHash("sha256")
+        .update(components.join("|"))
+        .digest("hex");
+}
+function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
+    if (sharedPrefix && sharedPrefix.trim() !== "") {
+        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    }
+    return ["cache", repository, version].join("/");
+}
+function normalizeS3Prefix(prefix) {
+    return prefix.trim().replace(/^\/+|\/+$/g, "");
+}
 
 
 /***/ }),

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -74070,10 +74070,10 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
     const repository = process.env.GITHUB_REPOSITORY;
-    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const repoPrefix = process.env.RUNS_ON_S3_CACHE_REPO_PREFIX;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    if (sharedPrefix && sharedPrefix.trim() !== "") {
-        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    if (repoPrefix && repoPrefix.trim() !== "") {
+        return [normalizeS3Prefix(repoPrefix), version].join("/");
     }
     return ["cache", repository, version].join("/");
 }

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -73306,18 +73306,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCacheVersion = getCacheVersion;
 exports.getCacheEntry = getCacheEntry;
 exports.downloadCache = downloadCache;
 exports.saveCache = saveCache;
-const client_s3_1 = __nccwpck_require__(53711);
-const { getSignedUrl } = __nccwpck_require__(18505);
-const fs_1 = __nccwpck_require__(79896);
-const crypto = __importStar(__nccwpck_require__(76982));
-const core = __importStar(__nccwpck_require__(37484));
 const utils = __importStar(__nccwpck_require__(98299));
+const core = __importStar(__nccwpck_require__(37484));
+const client_s3_1 = __nccwpck_require__(53711);
 const lib_storage_1 = __nccwpck_require__(22358);
+const s3_request_presigner_1 = __nccwpck_require__(18505);
+const fs_1 = __nccwpck_require__(79896);
 const downloadUtils_1 = __nccwpck_require__(118);
+const prefix_1 = __nccwpck_require__(33327);
 // if executing from RunsOn, unset any existing AWS credential env variables so that we can use the IAM instance profile for credentials
 // see unsetCredentials() in https://github.com/aws-actions/configure-aws-credentials/blob/v4.0.2/src/helpers.ts#L44
 // Note: we preserve AWS_REGION and AWS_DEFAULT_REGION as they are needed for SDK initialization
@@ -73326,7 +73325,6 @@ if (process.env.RUNS_ON_RUNNER_NAME && process.env.RUNS_ON_RUNNER_NAME !== "") {
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
 }
-const versionSalt = "1.0";
 const bucketName = process.env.RUNS_ON_S3_BUCKET_CACHE;
 const endpoint = process.env.RUNS_ON_S3_BUCKET_ENDPOINT;
 const region = process.env.RUNS_ON_AWS_REGION ||
@@ -73339,36 +73337,12 @@ const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 102
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
 const downloadPartSize = Number(process.env.DOWNLOAD_PART_SIZE || "16") * 1024 * 1024;
 const s3Client = new client_s3_1.S3Client({ region, forcePathStyle, endpoint });
-function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
-    // don't pass changes upstream
-    const components = paths.slice();
-    // Add compression method to cache version to restore
-    // compressed cache as per compression method
-    if (compressionMethod) {
-        components.push(compressionMethod);
-    }
-    // Only check for windows platforms if enableCrossOsArchive is false
-    if (process.platform === "win32" && !enableCrossOsArchive) {
-        components.push("windows-only");
-    }
-    // Add salt to cache version to support breaking changes in cache entry
-    components.push(versionSalt);
-    return crypto
-        .createHash("sha256")
-        .update(components.join("|"))
-        .digest("hex");
-}
-function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
-    const repository = process.env.GITHUB_REPOSITORY;
-    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    return ["cache", repository, version].join("/");
-}
 function getCacheEntry(keys_1, paths_1, _a) {
     return __awaiter(this, arguments, void 0, function* (keys, paths, { compressionMethod, enableCrossOsArchive }) {
         const cacheEntry = {};
         // Find the most recent key matching one of the restoreKeys prefixes
         for (const restoreKey of keys) {
-            const s3Prefix = getS3Prefix(paths, {
+            const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
                 compressionMethod,
                 enableCrossOsArchive
             });
@@ -73413,7 +73387,7 @@ function downloadCache(archiveLocation, archivePath, options) {
                     Bucket: bucketName,
                     Key: objectKey
                 });
-                const url = yield getSignedUrl(s3Client, command, {
+                const url = yield (0, s3_request_presigner_1.getSignedUrl)(s3Client, command, {
                     expiresIn: 3600
                 });
                 yield (0, downloadUtils_1.downloadCacheHttpClientConcurrent)(url, archivePath, Object.assign(Object.assign({}, options), { downloadConcurrency: downloadQueueSize, concurrentBlobDownloads: true, partSize: downloadPartSize }));
@@ -73442,15 +73416,16 @@ function downloadCache(archiveLocation, archivePath, options) {
         throw lastError || new Error("Download failed after all retry attempts");
     });
 }
-function saveCache(key_1, paths_1, archivePath_1, _a) {
-    return __awaiter(this, arguments, void 0, function* (key, paths, archivePath, { compressionMethod, enableCrossOsArchive, cacheSize: archiveFileSize }) {
+function saveCache(key, paths, archivePath, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { compressionMethod, enableCrossOsArchive } = options;
         if (!bucketName) {
             throw new Error("Environment variable RUNS_ON_S3_BUCKET_CACHE not set");
         }
         if (!region) {
             throw new Error("Environment variable RUNS_ON_AWS_REGION not set");
         }
-        const s3Prefix = getS3Prefix(paths, {
+        const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
             compressionMethod,
             enableCrossOsArchive
         });
@@ -74027,6 +74002,84 @@ const promiseWithTimeout = (timeoutMs, promise) => __awaiter(void 0, void 0, voi
         return result;
     });
 });
+
+
+/***/ }),
+
+/***/ 33327:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getCacheVersion = getCacheVersion;
+exports.getS3Prefix = getS3Prefix;
+const crypto = __importStar(__nccwpck_require__(76982));
+const versionSalt = "1.0";
+function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
+    // don't pass changes upstream
+    const components = paths.slice();
+    // Add compression method to cache version to restore
+    // compressed cache as per compression method
+    if (compressionMethod) {
+        components.push(compressionMethod);
+    }
+    // Only check for windows platforms if enableCrossOsArchive is false
+    if (process.platform === "win32" && !enableCrossOsArchive) {
+        components.push("windows-only");
+    }
+    // Add salt to cache version to support breaking changes in cache entry
+    components.push(versionSalt);
+    return crypto
+        .createHash("sha256")
+        .update(components.join("|"))
+        .digest("hex");
+}
+function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
+    if (sharedPrefix && sharedPrefix.trim() !== "") {
+        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    }
+    return ["cache", repository, version].join("/");
+}
+function normalizeS3Prefix(prefix) {
+    return prefix.trim().replace(/^\/+|\/+$/g, "");
+}
 
 
 /***/ }),

--- a/dist/save-only/index.js
+++ b/dist/save-only/index.js
@@ -74070,10 +74070,10 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
     const repository = process.env.GITHUB_REPOSITORY;
-    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const repoPrefix = process.env.RUNS_ON_S3_CACHE_REPO_PREFIX;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    if (sharedPrefix && sharedPrefix.trim() !== "") {
-        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    if (repoPrefix && repoPrefix.trim() !== "") {
+        return [normalizeS3Prefix(repoPrefix), version].join("/");
     }
     return ["cache", repository, version].join("/");
 }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -73306,18 +73306,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCacheVersion = getCacheVersion;
 exports.getCacheEntry = getCacheEntry;
 exports.downloadCache = downloadCache;
 exports.saveCache = saveCache;
-const client_s3_1 = __nccwpck_require__(53711);
-const { getSignedUrl } = __nccwpck_require__(18505);
-const fs_1 = __nccwpck_require__(79896);
-const crypto = __importStar(__nccwpck_require__(76982));
-const core = __importStar(__nccwpck_require__(37484));
 const utils = __importStar(__nccwpck_require__(98299));
+const core = __importStar(__nccwpck_require__(37484));
+const client_s3_1 = __nccwpck_require__(53711);
 const lib_storage_1 = __nccwpck_require__(22358);
+const s3_request_presigner_1 = __nccwpck_require__(18505);
+const fs_1 = __nccwpck_require__(79896);
 const downloadUtils_1 = __nccwpck_require__(118);
+const prefix_1 = __nccwpck_require__(33327);
 // if executing from RunsOn, unset any existing AWS credential env variables so that we can use the IAM instance profile for credentials
 // see unsetCredentials() in https://github.com/aws-actions/configure-aws-credentials/blob/v4.0.2/src/helpers.ts#L44
 // Note: we preserve AWS_REGION and AWS_DEFAULT_REGION as they are needed for SDK initialization
@@ -73326,7 +73325,6 @@ if (process.env.RUNS_ON_RUNNER_NAME && process.env.RUNS_ON_RUNNER_NAME !== "") {
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
 }
-const versionSalt = "1.0";
 const bucketName = process.env.RUNS_ON_S3_BUCKET_CACHE;
 const endpoint = process.env.RUNS_ON_S3_BUCKET_ENDPOINT;
 const region = process.env.RUNS_ON_AWS_REGION ||
@@ -73339,36 +73337,12 @@ const uploadPartSize = Number(process.env.UPLOAD_PART_SIZE || "32") * 1024 * 102
 const downloadQueueSize = Number(process.env.DOWNLOAD_QUEUE_SIZE || "8");
 const downloadPartSize = Number(process.env.DOWNLOAD_PART_SIZE || "16") * 1024 * 1024;
 const s3Client = new client_s3_1.S3Client({ region, forcePathStyle, endpoint });
-function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
-    // don't pass changes upstream
-    const components = paths.slice();
-    // Add compression method to cache version to restore
-    // compressed cache as per compression method
-    if (compressionMethod) {
-        components.push(compressionMethod);
-    }
-    // Only check for windows platforms if enableCrossOsArchive is false
-    if (process.platform === "win32" && !enableCrossOsArchive) {
-        components.push("windows-only");
-    }
-    // Add salt to cache version to support breaking changes in cache entry
-    components.push(versionSalt);
-    return crypto
-        .createHash("sha256")
-        .update(components.join("|"))
-        .digest("hex");
-}
-function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
-    const repository = process.env.GITHUB_REPOSITORY;
-    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    return ["cache", repository, version].join("/");
-}
 function getCacheEntry(keys_1, paths_1, _a) {
     return __awaiter(this, arguments, void 0, function* (keys, paths, { compressionMethod, enableCrossOsArchive }) {
         const cacheEntry = {};
         // Find the most recent key matching one of the restoreKeys prefixes
         for (const restoreKey of keys) {
-            const s3Prefix = getS3Prefix(paths, {
+            const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
                 compressionMethod,
                 enableCrossOsArchive
             });
@@ -73413,7 +73387,7 @@ function downloadCache(archiveLocation, archivePath, options) {
                     Bucket: bucketName,
                     Key: objectKey
                 });
-                const url = yield getSignedUrl(s3Client, command, {
+                const url = yield (0, s3_request_presigner_1.getSignedUrl)(s3Client, command, {
                     expiresIn: 3600
                 });
                 yield (0, downloadUtils_1.downloadCacheHttpClientConcurrent)(url, archivePath, Object.assign(Object.assign({}, options), { downloadConcurrency: downloadQueueSize, concurrentBlobDownloads: true, partSize: downloadPartSize }));
@@ -73442,15 +73416,16 @@ function downloadCache(archiveLocation, archivePath, options) {
         throw lastError || new Error("Download failed after all retry attempts");
     });
 }
-function saveCache(key_1, paths_1, archivePath_1, _a) {
-    return __awaiter(this, arguments, void 0, function* (key, paths, archivePath, { compressionMethod, enableCrossOsArchive, cacheSize: archiveFileSize }) {
+function saveCache(key, paths, archivePath, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { compressionMethod, enableCrossOsArchive } = options;
         if (!bucketName) {
             throw new Error("Environment variable RUNS_ON_S3_BUCKET_CACHE not set");
         }
         if (!region) {
             throw new Error("Environment variable RUNS_ON_AWS_REGION not set");
         }
-        const s3Prefix = getS3Prefix(paths, {
+        const s3Prefix = (0, prefix_1.getS3Prefix)(paths, {
             compressionMethod,
             enableCrossOsArchive
         });
@@ -74027,6 +74002,84 @@ const promiseWithTimeout = (timeoutMs, promise) => __awaiter(void 0, void 0, voi
         return result;
     });
 });
+
+
+/***/ }),
+
+/***/ 33327:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getCacheVersion = getCacheVersion;
+exports.getS3Prefix = getS3Prefix;
+const crypto = __importStar(__nccwpck_require__(76982));
+const versionSalt = "1.0";
+function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
+    // don't pass changes upstream
+    const components = paths.slice();
+    // Add compression method to cache version to restore
+    // compressed cache as per compression method
+    if (compressionMethod) {
+        components.push(compressionMethod);
+    }
+    // Only check for windows platforms if enableCrossOsArchive is false
+    if (process.platform === "win32" && !enableCrossOsArchive) {
+        components.push("windows-only");
+    }
+    // Add salt to cache version to support breaking changes in cache entry
+    components.push(versionSalt);
+    return crypto
+        .createHash("sha256")
+        .update(components.join("|"))
+        .digest("hex");
+}
+function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
+    if (sharedPrefix && sharedPrefix.trim() !== "") {
+        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    }
+    return ["cache", repository, version].join("/");
+}
+function normalizeS3Prefix(prefix) {
+    return prefix.trim().replace(/^\/+|\/+$/g, "");
+}
 
 
 /***/ }),

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -74070,10 +74070,10 @@ function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false)
 }
 function getS3Prefix(paths, { compressionMethod, enableCrossOsArchive }) {
     const repository = process.env.GITHUB_REPOSITORY;
-    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const repoPrefix = process.env.RUNS_ON_S3_CACHE_REPO_PREFIX;
     const version = getCacheVersion(paths, compressionMethod, enableCrossOsArchive);
-    if (sharedPrefix && sharedPrefix.trim() !== "") {
-        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    if (repoPrefix && repoPrefix.trim() !== "") {
+        return [normalizeS3Prefix(repoPrefix), version].join("/");
     }
     return ["cache", repository, version].join("/");
 }

--- a/src/custom/backend.ts
+++ b/src/custom/backend.ts
@@ -1,20 +1,17 @@
-import {
-    S3Client,
-    GetObjectCommand,
-    ListObjectsV2Command
-} from "@aws-sdk/client-s3";
-const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
-import { createReadStream } from "fs";
-import * as crypto from "crypto";
-import {
-    DownloadOptions,
-    getDownloadOptions
-} from "@actions/cache/lib/options";
-import { CompressionMethod } from "@actions/cache/lib/internal/constants";
-import * as core from "@actions/core";
 import * as utils from "@actions/cache/lib/internal/cacheUtils";
+import { DownloadOptions } from "@actions/cache/lib/options";
+import * as core from "@actions/core";
+import {
+    GetObjectCommand,
+    ListObjectsV2Command,
+    S3Client
+} from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { createReadStream } from "fs";
+
 import { downloadCacheHttpClientConcurrent } from "./downloadUtils";
+import { getS3Prefix } from "./prefix";
 
 export interface ArtifactCacheEntry {
     cacheKey?: string;
@@ -33,7 +30,6 @@ if (process.env.RUNS_ON_RUNNER_NAME && process.env.RUNS_ON_RUNNER_NAME !== "") {
     delete process.env.AWS_SESSION_TOKEN;
 }
 
-const versionSalt = "1.0";
 const bucketName = process.env.RUNS_ON_S3_BUCKET_CACHE;
 const endpoint = process.env.RUNS_ON_S3_BUCKET_ENDPOINT;
 const region =
@@ -52,48 +48,6 @@ const downloadPartSize =
     Number(process.env.DOWNLOAD_PART_SIZE || "16") * 1024 * 1024;
 
 const s3Client = new S3Client({ region, forcePathStyle, endpoint });
-
-export function getCacheVersion(
-    paths: string[],
-    compressionMethod?: CompressionMethod,
-    enableCrossOsArchive = false
-): string {
-    // don't pass changes upstream
-    const components = paths.slice();
-
-    // Add compression method to cache version to restore
-    // compressed cache as per compression method
-    if (compressionMethod) {
-        components.push(compressionMethod);
-    }
-
-    // Only check for windows platforms if enableCrossOsArchive is false
-    if (process.platform === "win32" && !enableCrossOsArchive) {
-        components.push("windows-only");
-    }
-
-    // Add salt to cache version to support breaking changes in cache entry
-    components.push(versionSalt);
-
-    return crypto
-        .createHash("sha256")
-        .update(components.join("|"))
-        .digest("hex");
-}
-
-function getS3Prefix(
-    paths: string[],
-    { compressionMethod, enableCrossOsArchive }
-): string {
-    const repository = process.env.GITHUB_REPOSITORY;
-    const version = getCacheVersion(
-        paths,
-        compressionMethod,
-        enableCrossOsArchive
-    );
-
-    return ["cache", repository, version].join("/");
-}
 
 export async function getCacheEntry(
     keys,
@@ -210,8 +164,10 @@ export async function saveCache(
     key: string,
     paths: string[],
     archivePath: string,
-    { compressionMethod, enableCrossOsArchive, cacheSize: archiveFileSize }
+    options
 ): Promise<void> {
+    const { compressionMethod, enableCrossOsArchive } = options;
+
     if (!bucketName) {
         throw new Error("Environment variable RUNS_ON_S3_BUCKET_CACHE not set");
     }

--- a/src/custom/prefix.ts
+++ b/src/custom/prefix.ts
@@ -1,0 +1,55 @@
+import { CompressionMethod } from "@actions/cache/lib/internal/constants";
+import * as crypto from "crypto";
+
+const versionSalt = "1.0";
+
+export function getCacheVersion(
+    paths: string[],
+    compressionMethod?: CompressionMethod,
+    enableCrossOsArchive = false
+): string {
+    // don't pass changes upstream
+    const components = paths.slice();
+
+    // Add compression method to cache version to restore
+    // compressed cache as per compression method
+    if (compressionMethod) {
+        components.push(compressionMethod);
+    }
+
+    // Only check for windows platforms if enableCrossOsArchive is false
+    if (process.platform === "win32" && !enableCrossOsArchive) {
+        components.push("windows-only");
+    }
+
+    // Add salt to cache version to support breaking changes in cache entry
+    components.push(versionSalt);
+
+    return crypto
+        .createHash("sha256")
+        .update(components.join("|"))
+        .digest("hex");
+}
+
+export function getS3Prefix(
+    paths: string[],
+    { compressionMethod, enableCrossOsArchive }
+): string {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const version = getCacheVersion(
+        paths,
+        compressionMethod,
+        enableCrossOsArchive
+    );
+
+    if (sharedPrefix && sharedPrefix.trim() !== "") {
+        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    }
+
+    return ["cache", repository, version].join("/");
+}
+
+function normalizeS3Prefix(prefix: string): string {
+    return prefix.trim().replace(/^\/+|\/+$/g, "");
+}

--- a/src/custom/prefix.ts
+++ b/src/custom/prefix.ts
@@ -36,15 +36,15 @@ export function getS3Prefix(
     { compressionMethod, enableCrossOsArchive }
 ): string {
     const repository = process.env.GITHUB_REPOSITORY;
-    const sharedPrefix = process.env.RUNS_ON_S3_CACHE_SHARED_PREFIX;
+    const repoPrefix = process.env.RUNS_ON_S3_CACHE_REPO_PREFIX;
     const version = getCacheVersion(
         paths,
         compressionMethod,
         enableCrossOsArchive
     );
 
-    if (sharedPrefix && sharedPrefix.trim() !== "") {
-        return [normalizeS3Prefix(sharedPrefix), version].join("/");
+    if (repoPrefix && repoPrefix.trim() !== "") {
+        return [normalizeS3Prefix(repoPrefix), version].join("/");
     }
 
     return ["cache", repository, version].join("/");


### PR DESCRIPTION
## User-facing changes

- Uses `RUNS_ON_S3_CACHE_REPO_PREFIX` when RunsOn provides it, storing v5 caches under `cache/repo/<owner>/<repo>/...`.
- Keeps `cache/<owner>/<repo>/...` as the fallback outside RunsOn or when the variable is absent.
- Existing entries are not dual-read, so the first run after upgrading may be a cold cache.

## Reviewer notes

- The prefix is normalized before the cache version is appended.
- Source tests cover both the RunsOn prefix and fallback. All four v5 distribution bundles were rebuilt and verified against a clean build.
- Local validation passed: TypeScript build, Jest (82 tests), lint, formatting, and clean dist reproduction.