### PR TITLE
Fix cross-OS S3 cache restore

### DIFF
--- a/dist/restore-only/index.js
+++ b/dist/restore-only/index.js
@@ -74113,7 +74113,7 @@ function restoreImpl(stateProvider, earlyExit) {
             let cacheKey;
             if (canSaveToS3) {
                 core.info("The cache action detected a local S3 bucket cache. Using it.");
-                cacheKey = yield custom.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly });
+                cacheKey = yield custom.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);
             }
             else {
                 cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -74113,7 +74113,7 @@ function restoreImpl(stateProvider, earlyExit) {
             let cacheKey;
             if (canSaveToS3) {
                 core.info("The cache action detected a local S3 bucket cache. Using it.");
-                cacheKey = yield custom.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly });
+                cacheKey = yield custom.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);
             }
             else {
                 cacheKey = yield cache.restoreCache(cachePaths, primaryKey, restoreKeys, { lookupOnly: lookupOnly }, enableCrossOsArchive);

--- a/src/restoreImpl.ts
+++ b/src/restoreImpl.ts
@@ -55,7 +55,8 @@ export async function restoreImpl(
                 cachePaths,
                 primaryKey,
                 restoreKeys,
-                { lookupOnly: lookupOnly }
+                { lookupOnly: lookupOnly },
+                enableCrossOsArchive
             );
         } else {
             cacheKey = await cache.restoreCache(


### PR DESCRIPTION
## Description

Pass `enableCrossOsArchive` to `custom.restoreCache()` on the S3 restore path in `restoreImpl.ts`, matching the existing GitHub-cache branch and the S3 save path in `saveImpl.ts`.

Without this, Linux saves a cache entry under the cross-OS version hash, but Windows restore lookups use the default (OS-specific) hash and miss the entry.

## Motivation and Context

Fixes #43.

On the S3 backend, `saveImpl.ts` already forwards `enableCrossOsArchive` to `custom.saveCache()`, but `restoreImpl.ts` did not forward it to `custom.restoreCache()`. The GitHub-cache code path was unaffected because it always passed the flag.

## How Has This Been Tested?

End-to-end regression test in [SonarSource/gh-action_cache#84](https://github.com/SonarSource/gh-action_cache/pull/84), pinning `matemoln/cache@fix/cross-os-s3-restore`:

- **Workflow run:** https://github.com/SonarSource/gh-action_cache/actions/runs/28442920844
- **Linux save job (passing):** https://github.com/SonarSource/gh-action_cache/actions/runs/28442920844/job/84284995900
- **Windows restore job (passing):** https://github.com/SonarSource/gh-action_cache/actions/runs/28442920844/job/84285217343

Scenario:

1. **Linux** saves `.cross-os-cache-test.txt` to S3 with `enableCrossOsArchive: true`
2. **Windows** (GitHub hosted large runner) restores the same key with `enableCrossOsArchive: true`

Windows restore log confirms the fix:

```
Received 212 of 212 (100.0%), 0.0 MBs/sec
Cache restored successfully
Cache restored from key: fix/cross-os-s3-repro/cross-os-s3-28442920844
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.